### PR TITLE
ci: remove `need` field

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Remove the `need` field since the workflow will be executed after some PR being merged into `main` branch. And if a PR was merged, it will trigger the `test` workflow.